### PR TITLE
refactor: RedisLock 파라미터 파싱 수정

### DIFF
--- a/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/ReserveSeatUseCase.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/ReserveSeatUseCase.java
@@ -28,7 +28,7 @@ public class ReserveSeatUseCase {
     }
 
     // 좌석 임시 예약 처리 메서드
-    @RedisLock(keyExpression = "'seat-lock:' + #reservationInput.seatId", waitTime = 5, leaseTime = 10)
+    @RedisLock(keyGenerator = "generateLockKey", waitTime = 5, leaseTime = 10)
     public ReservationOutput reserveSeat(ReservationInput reservationInput) {
         Seat seat = seatRepository.findById(reservationInput.getSeatId())
                 .orElseThrow(() -> new NoSuchElementException("좌석을 찾을 수 없습니다."));
@@ -62,6 +62,11 @@ public class ReserveSeatUseCase {
         );
     }
 
+    // 고유 락 키 생성 메서드
+    public String generateLockKey(ReservationInput reservationInput) {
+        return "seat-lock:" + reservationInput.getSeatId();
+    }
+
     // 예약된 좌석의 상태 조회 메서드
     public List<ReservationOutput> getReservationStatus(Long seatId) {
         List<Reservation> reservations = reservationRepository.findAllBySeatId(seatId);
@@ -93,4 +98,3 @@ public class ReserveSeatUseCase {
         seatRepository.save(seat);
     }
 }
-

--- a/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/ReserveSeatUseCase.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/ReserveSeatUseCase.java
@@ -28,7 +28,7 @@ public class ReserveSeatUseCase {
     }
 
     // 좌석 임시 예약 처리 메서드
-    @RedisLock(keyParameterIndex = 0, waitTime = 5, leaseTime = 10)
+    @RedisLock(keyExpression = "'seat-lock:' + #reservationInput.seatId", waitTime = 5, leaseTime = 10)
     public ReservationOutput reserveSeat(ReservationInput reservationInput) {
         Seat seat = seatRepository.findById(reservationInput.getSeatId())
                 .orElseThrow(() -> new NoSuchElementException("좌석을 찾을 수 없습니다."));

--- a/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/RedisLockAspect.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/RedisLockAspect.java
@@ -4,6 +4,7 @@ import com.hhplus.concert.config.aop.annotation.RedisLock;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.expression.ExpressionParser;
@@ -14,10 +15,12 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.TimeUnit;
 
 @Aspect
+//@Order(1) AopForTransaction 클래스 사용 안 하고 메서드에 @Transactional 처리
 @Component
 public class RedisLockAspect {
     private final RedissonClient redissonClient;
     private  final AopForTransaction aopForTransaction;
+    private final ExpressionParser parser = new SpelExpressionParser();
 
     public RedisLockAspect(RedissonClient redissonClient, AopForTransaction aopForTransaction) {
         this.redissonClient = redissonClient;
@@ -26,8 +29,7 @@ public class RedisLockAspect {
 
     @Around("@annotation(redisLock)")
     public Object aroundRedisLock(ProceedingJoinPoint joinPoint, RedisLock redisLock) throws Throwable{
-        Object keyParam = joinPoint.getArgs()[redisLock.keyParameterIndex()];
-        String key = redisLock.keyPrefix() + keyParam.toString();
+        String key = parseKey(redisLock.keyExpression(), joinPoint);
 
         RLock lock = redissonClient.getLock(key);
 
@@ -45,5 +47,19 @@ public class RedisLockAspect {
             }
         }
 
+    }
+
+    private String parseKey(String keyExpression, ProceedingJoinPoint joinPoint) {
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Object[] args = joinPoint.getArgs();
+
+        // 메서드 파라미터 이름과 값을 SpEL 컨텍스트에 추가
+        for (int i = 0; i < signature.getParameterNames().length; i++) {
+            context.setVariable(signature.getParameterNames()[i], args[i]);
+        }
+
+        // keyExpression을 SpEL로 평가하여 키 생성
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
     }
 }

--- a/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/annotation/RedisLock.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/annotation/RedisLock.java
@@ -5,7 +5,7 @@ import java.lang.annotation.*;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RedisLock {
-    String keyExpression();
+    String keyGenerator() default "";
     long waitTime() default 5;  // 락을 기다리는 최대 시간 (초)
     long leaseTime() default 10; // 락 점유 시간 (초)
 }

--- a/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/annotation/RedisLock.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/annotation/RedisLock.java
@@ -5,8 +5,7 @@ import java.lang.annotation.*;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RedisLock {
-    int keyParameterIndex();
-    String keyPrefix() default "seat-lock:";
+    String keyExpression();
     long waitTime() default 5;  // 락을 기다리는 최대 시간 (초)
     long leaseTime() default 10; // 락 점유 시간 (초)
 }


### PR DESCRIPTION
### 변경 내용
1. 파라미터 인덱스를 통한 잠금 키 설정이 파라미터 순서나 이름에 의존하게 되어있어 유지보수성이 떨어질 수 있으므로, 키를 인덱스 대신 식(expression)으로 정의하고 이를 평가하여 키를 생성하는 방식으로 처리했습니다.
- RedisLock 애노테이션에서는 keyParameterIndex 대신 keyExpression을 사용하여 SpEL(Expression Language)로 파라미터를 직접 지정할 수 있게 합니다.
- RedisLockAspect는 keyExpression을 SpEL로 평가하여 잠금 키를 생성합니다

### 리뷰 코멘트
변수명이나 필드명이 변경되거나 객체 구조가 달라지면 잠금 로직에도 수정이 필요하게 되어, 유지보수에 취약할 수 있습니다.
keyExpression = "'seat-lock:' + #reservationInput.seatId"와 같이 특정 필드(seatId)에 직접 접근하는 방식은 변수명 변경이나 구조 변경에 취약합니다. 여기서 `reservationInput`이나 `seatId`가 변경되거나 삭제된다면, 해당 표현식이 더 이상 작동하지 않을 수 있습니다. 이는 `@RedisLock`의 **키 파싱 로직이 변수명에 의존**하고 있기 때문에 발생하는 문제입니다.
즉, **변수명이나 파라미터 구조가 바뀌면 락을 거는 로직이 제대로 동작하지 않거나, 의도하지 않은 락이 걸릴 수 있는** 위험이 있습니다.

이 문제를 해결하기 위해서 고유 식별자를 기반으로 키를 생성하는 방식을 사용했습니다. **@RedisLock**의 키 생성 부분이 변수명이나 파라미터 순서에 의존하지 않도록, **클래스나 메서드 레벨에서 항상 일관된 고유한 식별자를 제공하는 방식**이 안정적인 접근 방식이라고 생각했습니다. 제가 생각한 방식이 해결책으로 옳은 대안인지 알려주시면 감사합니다.