### PR TITLE
feat: 콘서트 예약 가능 날짜 조회에서 redis 캐시를 활용

### DIFF
--- a/hhplus-concert/src/main/java/com/hhplus/concert/HhplusConcertApplication.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/HhplusConcertApplication.java
@@ -2,8 +2,10 @@ package com.hhplus.concert;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class HhplusConcertApplication {
 
     public static void main(String[] args) {

--- a/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/ReserveSeatUseCase.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/ReserveSeatUseCase.java
@@ -2,19 +2,15 @@ package com.hhplus.concert.application.usecase;
 
 import com.hhplus.concert.application.dto.input.ReservationInput;
 import com.hhplus.concert.application.dto.output.ReservationOutput;
-import com.hhplus.concert.config.aop.annotation.RedisLock;
+import com.hhplus.concert.config.aop.annotation.DistributedLock;
 import com.hhplus.concert.domain.reservation.Reservation;
 import com.hhplus.concert.domain.seat.Seat;
 import com.hhplus.concert.infrastructure.repository.ReservationRepository;
 import com.hhplus.concert.infrastructure.repository.SeatRepository;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,7 +24,7 @@ public class ReserveSeatUseCase {
     }
 
     // 좌석 임시 예약 처리 메서드
-    @RedisLock(keyGenerator = "generateLockKey", waitTime = 5, leaseTime = 10)
+    @DistributedLock(keyGenerator = "generateLockKey", waitTime = 5, leaseTime = 10)
     public ReservationOutput reserveSeat(ReservationInput reservationInput) {
         Seat seat = seatRepository.findById(reservationInput.getSeatId())
                 .orElseThrow(() -> new NoSuchElementException("좌석을 찾을 수 없습니다."));

--- a/hhplus-concert/src/main/java/com/hhplus/concert/config/CacheConfig.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/config/CacheConfig.java
@@ -1,0 +1,41 @@
+package com.hhplus.concert.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    // 캐시 설정을 위한 CacheManager
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(1)) // TTL 설정
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+}

--- a/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/annotation/DistributedLock.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/config/aop/annotation/DistributedLock.java
@@ -4,7 +4,7 @@ import java.lang.annotation.*;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface RedisLock {
+public @interface DistributedLock {
     String keyGenerator() default "";
     long waitTime() default 5;  // 락을 기다리는 최대 시간 (초)
     long leaseTime() default 10; // 락 점유 시간 (초)

--- a/hhplus-concert/src/main/java/com/hhplus/concert/interfaces/api/concertschedule/ConcertScheduleController.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/interfaces/api/concertschedule/ConcertScheduleController.java
@@ -6,6 +6,7 @@ import com.hhplus.concert.application.usecase.GetAvailableDatesUseCase;
 import com.hhplus.concert.interfaces.api.concertschedule.dto.ConcertScheduleRequest;
 import com.hhplus.concert.interfaces.api.concertschedule.dto.ConcertScheduleResponse;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +23,7 @@ public class ConcertScheduleController {
     }
 
     // 예약 가능 날짜 조회 API
+    @Cacheable(value = "availableDates", key = "#request.concertId + '_' + #request.openAt")
     @GetMapping("/available-dates")
     public ResponseEntity<List<ConcertScheduleResponse>> getAvailableDates(@RequestBody ConcertScheduleRequest request) {
         ConcertScheduleInput input = new ConcertScheduleInput(

--- a/hhplus-concert/src/main/resources/application.yaml
+++ b/hhplus-concert/src/main/resources/application.yaml
@@ -10,6 +10,12 @@ spring:
         format_sql: true
     defer-datasource-initialization: true # 데이터베이스 초기화 지연
 
+  cache:
+    type: redis
+    redis:
+      host: localhost
+      port: 6379
+
   datasource:
     url: jdbc:mysql://localhost:3306/concert?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC
     username: testuser


### PR DESCRIPTION
### 변경 내역
1. RedisCacheManager와 TTL 설정 : TTL (Time-To-Live) 설정이 Duration.ofMinutes(1)로 되어 있으므로 캐시 항목은 1분 동안 유지됩니다
2. RedisTemplate과 직렬화 설정 : StringRedisSerializer와 GenericJackson2JsonRedisSerializer로 각각 키와 값을 직렬화/역직렬화합니다

### 리뷰 포인트 
- `CacheConfig`에서 **StringRedisSerializer**와 **GenericJackson2JsonRedisSerializer**로 각각 키와 값을 직렬화/역직렬화 설정을 잘 한 건지 확인해 주시면 감사합니다!
- 11월 7일(목) 멘토링 시간에 @Cacheable(key = "#request.concertId + '_' + #request.openAt") 와 같이 특정 필드에 직접 접근하는 방식 대신 1. Interface를 작성하여 락 key를 추출하는 방식 2. Annotation 락 키를 추출하는 방식은 아직 수정작업을 못 했습니다..ㅜㅜ 과제 제출 이후 리팩토링을 해보려고 합니다!