### PR TITLE
feat: Redis를 이용한 대기열 위치 조회

### DIFF
--- a/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/QueuePositionUseCase.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/QueuePositionUseCase.java
@@ -3,6 +3,8 @@ package com.hhplus.concert.application.usecase;
 import com.hhplus.concert.application.dto.output.QueueOutput;
 import com.hhplus.concert.domain.queue.Queue;
 import com.hhplus.concert.infrastructure.repository.QueueRepository;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
@@ -10,37 +12,24 @@ import java.util.UUID;
 
 @Service
 public class QueuePositionUseCase {
-    private final QueueRepository queueRepository;
-    private final CalculateRemainingTimeUseCase calculateRemainingTimeUseCase;
+    private final RedissonClient redissonClient;
+    private static final String QUEUE_KEY = "userQueue";
 
-    public QueuePositionUseCase(QueueRepository queueRepository, CalculateRemainingTimeUseCase calculateRemainingTimeUseCase) {
-        this.queueRepository = queueRepository;
-        this.calculateRemainingTimeUseCase = calculateRemainingTimeUseCase;
+    public QueuePositionUseCase(RedissonClient redissonClient) {
+        this.redissonClient = redissonClient;
     }
 
+
     // 대기열에서 현재 몇 번째 순서인지 조회하는 메서드
-    public QueueOutput getQueuePosition(String token, UUID userId) {
-        Queue queue = queueRepository.findByTokenAndUserId(token, userId)
-                .orElseThrow(() -> new NoSuchElementException("유효하지 않은 토큰입니다."));
+    public long getQueuePosition(String token) {
+        RScoredSortedSet<String> queueSet = redissonClient.getScoredSortedSet(QUEUE_KEY);
+        Integer rank = queueSet.rank(token);
 
-        // 현재 활성화된 대기열 수 확인
-        long activeCount = queueRepository.countByStatus("ACTIVE");
+        if (rank == null) {
+            throw new NoSuchElementException("유효하지 않은 토큰입니다.");
+        }
 
-        // 현재 사용자보다 앞에 있는 대기열 수 확인
-        long currentPosition = queueRepository.countByStatusAndQueuePositionLessThan("WAITING", queue.getQueuePosition()) + 1;
-
-        long remainingTime = calculateRemainingTimeUseCase.calculateRemainingTime(queue.getExpiredAt());
-
-        return new QueueOutput(
-                queue.getUserId(),
-                queue.getToken(),
-                queue.getStatus(),
-                queue.getEnteredAt(),
-                queue.getExpiredAt(),
-                queue.getQueuePosition(),
-                currentPosition,
-                activeCount,
-                remainingTime
-        );
+        // Redis의 rank는 0부터 시작하므로 1을 더해서 순서 반환
+        return rank + 1;
     }
 }

--- a/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/QueueProcessingScheduler.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/QueueProcessingScheduler.java
@@ -2,55 +2,50 @@ package com.hhplus.concert.application.usecase;
 
 import com.hhplus.concert.domain.queue.Queue;
 import com.hhplus.concert.infrastructure.repository.QueueRepository;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 @Component
 public class QueueProcessingScheduler {
-    private final QueueRepository queueRepository;
+    private final RedissonClient redissonClient;
     private static final int MAX_ACTIVE_COUNT = 5;
+    private static final String QUEUE_KEY = "userQueue";
 
-    public QueueProcessingScheduler(QueueRepository queueRepository) {
-        this.queueRepository = queueRepository;
+    public QueueProcessingScheduler(RedissonClient redissonClient) {
+        this.redissonClient = redissonClient;
     }
+
 
     // 1분마다 대기열에서 만료된 항목 처리
     @Scheduled(fixedRate = 60000)  // 1분마다 실행
     public void processExpiredQueues() {
-        LocalDateTime now = LocalDateTime.now();
-        List<Queue> expiredQueues = queueRepository.findAllByExpiredAtBeforeAndStatus(now, "WAITING");
+        RScoredSortedSet<String> queueSet = redissonClient.getScoredSortedSet(QUEUE_KEY);
+        double currentTime = Instant.now().getEpochSecond();
 
-        for (Queue queue : expiredQueues) {
-            queue.setStatus("EXPIRED");
-            queueRepository.save(queue);
-        }
+        // 만료된 항목 제거
+        int removedCount = queueSet.removeRangeByScore(0, true, currentTime, true);
+        System.out.println("Removed expired entries: " + removedCount);
     }
 
     // 대기열 순차 활성화
     @Scheduled(fixedRate = 60000)
-    public void activateNextInQueue(UUID userId) {
-        long activeCount = queueRepository.countByStatus("ACTIVE");
+    public void activateNextInQueue() {
+        RScoredSortedSet<String> queueSet = redissonClient.getScoredSortedSet(QUEUE_KEY);
+        long activeCount = queueSet.size();
 
-        // 활성화 가능한 항목이 더 있는지 확인
         if (activeCount < MAX_ACTIVE_COUNT) {
-            List<Queue> waitingQueues = queueRepository.findAllByUserIdAndStatus(userId,"WAITING");
-
-            if (!waitingQueues.isEmpty()) {
-                // 활성화할 대기열 항목 수를 최대 활성화 가능 수로 제한
-                int remainingActivations = MAX_ACTIVE_COUNT - (int) activeCount;
-                List<Queue> nextInQueue = waitingQueues.subList(0, Math.min(remainingActivations, waitingQueues.size()));
-
-                for (Queue queue : nextInQueue) {
-                    queue.setStatus("ACTIVE");
-                    queueRepository.save(queue);
-                }
-            }
+            queueSet.stream()
+                    .limit(MAX_ACTIVE_COUNT - activeCount)
+                    .forEach(token -> {
+                        System.out.println("Activating user with token: " + token);
+                    });
         }
     }
-
-
 }

--- a/hhplus-concert/src/main/java/com/hhplus/concert/interfaces/api/queue/QueueController.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/interfaces/api/queue/QueueController.java
@@ -46,22 +46,8 @@ public class QueueController {
 
     // 대기열 위치 조회 API
     @GetMapping("/position/{token}")
-    public ResponseEntity<QueueResponse> getQueuePosition(@PathVariable String token , @RequestHeader("User-Id") String userIdHeader) {
-        UUID userId = UUID.fromString(userIdHeader);
-
-        QueueOutput queueOutput = queuePositionUseCase.getQueuePosition(token, userId);
-
-        QueueResponse response = new QueueResponse(
-                queueOutput.getUserId(),
-                queueOutput.getToken(),
-                queueOutput.getStatus(),
-                queueOutput.getEnteredAt(),
-                queueOutput.getExpiredAt(),
-                queueOutput.getQueuePosition(),
-                queueOutput.getCurrentPosition(),
-                queueOutput.getActiveCount(),
-                queueOutput.getRemainingTime()
-        );
-        return ResponseEntity.ok(response);
+    public ResponseEntity<Long> getQueuePosition(@PathVariable String token) {
+        long position = queuePositionUseCase.getQueuePosition(token);
+        return ResponseEntity.ok(position);
     }
 }


### PR DESCRIPTION
### 변경 내용
1. Redis Sorted Set을 사용하여 대기열 관리 및 활성화 처리.
2. 기존 `QueueRepository` 기반의 로직을 Redis를 활용한 로직으로 변경.
3. 컨트롤러에서 Redis 기반 로직에 맞춰 대기열 조회 및 위치 조회 API 수정.

### 리뷰 코멘트
현재의 QueueController에서 RedisQueuePositionUseCase를 호출하여 대기열의 위치를 반환하는 API는 간단하게 token을 받아 순서를 반환하는 구조로 작성되어 있습니다.
이 경우 input/output DTO가 필요 없을 것 같다고 판단하였습니다.
- 추가적인 정보(예: 사용자 ID, 대기열 상태 등)를 입력이나 출력으로 함께 다룰 필요가 있을 때를 대비해 dto를 사용하게끔 QueueController 수정하는게 좋을지 문의드립니다.