### PR TITLE
STEP16-결제서비스 트랜잭션의 범위와 서비스 분리 방안

### DIFF
--- a/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/PaymentProcessingUseCase.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/application/usecase/PaymentProcessingUseCase.java
@@ -44,14 +44,13 @@ public class PaymentProcessingUseCase {
         // 2. 유저 조회 및 잔액 차감
         ChargeOutput chargeOutput = deductBalanceUseCase.deductBalance(paymentInput.getUserId(), seat.getAmount());
 
-
-        // 3. 결제 정보 생성 및 저장
-        Payment payment = new Payment(paymentInput.getUserId(), paymentInput.getSeatId(), seat.getAmount(), "COMPLETED");
-        Payment savedPayment = paymentRepository.save(payment);
-
-        // 4. 좌석 상태 변경
+        // 3. 좌석 상태 변경
         seat.setSeatStatus("OCCUPIED");
         seatRepository.save(seat);
+
+        // 4. 결제 정보 생성 및 저장
+        Payment payment = new Payment(paymentInput.getUserId(), paymentInput.getSeatId(), seat.getAmount(), "COMPLETED");
+        Payment savedPayment = paymentRepository.save(payment);
 
         // 5. 대기열 토큰 만료
         Queue queue = queueRepository.findByUserIdAndStatus(payment.getUserId(), "ACTIVE")

--- a/hhplus-concert/src/main/java/com/hhplus/concert/domain/notification/NotificationEvent.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/domain/notification/NotificationEvent.java
@@ -1,0 +1,14 @@
+package com.hhplus.concert.domain.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationEvent {
+    private String message;
+}

--- a/hhplus-concert/src/main/java/com/hhplus/concert/domain/notification/NotificationEventListener.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/domain/notification/NotificationEventListener.java
@@ -1,0 +1,27 @@
+package com.hhplus.concert.domain.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNotification(NotificationEvent event) {
+        // 실제 알림 전송 로직 예시 (외부 API 호출 등)
+        try {
+            // 예시 코드: 실제 알림 서비스 호출
+            // notificationService.send(event.getMessage());
+            log.info("알림톡 전송 완료했습니다. : {}", event.getMessage());
+        } catch (Exception e) {
+            log.error("알림톡 전송에 실패했습니다. : {}", event.getMessage(), e);
+        }
+    }
+}

--- a/hhplus-concert/src/main/java/com/hhplus/concert/domain/payment/event/PaymentCompletedEvent.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/domain/payment/event/PaymentCompletedEvent.java
@@ -1,0 +1,17 @@
+package com.hhplus.concert.domain.payment.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentCompletedEvent {
+    private Long paymentId;
+    private UUID userId;
+}

--- a/hhplus-concert/src/main/java/com/hhplus/concert/domain/user/event/UserPointUsageEvent.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/domain/user/event/UserPointUsageEvent.java
@@ -1,0 +1,17 @@
+package com.hhplus.concert.domain.user.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPointUsageEvent {
+    private UUID userId;
+    private long amount;
+}

--- a/hhplus-concert/src/main/java/com/hhplus/concert/domain/user/event/UserPointUsageEventListener.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/domain/user/event/UserPointUsageEventListener.java
@@ -1,0 +1,21 @@
+package com.hhplus.concert.domain.user.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserPointUsageEventListener {
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleUserPointUsage(UserPointUsageEvent event){
+
+        log.info("포인트 사용이력 저장 userId: {} amount: {}", event.getUserId(), event.getAmount());
+        // 포인트 사용이력 저장 로직
+        // userService.saveUserPointUsage(event.getUserId(), event.getAmount());
+    }
+}

--- a/hhplus-concert/src/main/java/com/hhplus/concert/infrastructure/event/EventPublisher.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/infrastructure/event/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.hhplus.concert.infrastructure.event;
+
+public interface EventPublisher<T> {
+    void publish(T event);
+}

--- a/hhplus-concert/src/main/java/com/hhplus/concert/infrastructure/event/payment/PaymentEventPublisher.java
+++ b/hhplus-concert/src/main/java/com/hhplus/concert/infrastructure/event/payment/PaymentEventPublisher.java
@@ -1,0 +1,20 @@
+package com.hhplus.concert.infrastructure.event.payment;
+
+import com.hhplus.concert.domain.payment.event.PaymentCompletedEvent;
+import com.hhplus.concert.infrastructure.event.EventPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentEventPublisher implements EventPublisher<PaymentCompletedEvent> {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public PaymentEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    @Override
+    public void publish(PaymentCompletedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}


### PR DESCRIPTION
### 변경 내용
1. PaymentProcessingUseCase 수정 : '유저조회, 잔액차감, 유저포인트 사용이력 저장'도 포함하여
**예약조회 및 상태변경 -> 유저조회, 잔액차감, 유저포인트 사용이력 저장 -> 좌석 조회 및 상태변경 -> 결제 생성 및 저장 -> 대기열 만료처리의 비즈니스 로직을 구현**

2. 모놀로식 아키텍처에서 애플리케이션 이벤트를 통한 관심사 분리
- **포인트 사용 이력 저장**:
    - `@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)`를 사용하는 경우, 트랜잭션이 커밋되기 직전에 이벤트 핸들러가 실행됩니다. 따라서 포인트 사용 이력 저장과 관련된 로직은 트랜잭션이 커밋되기 전에 실행됩니다.
-  **알림 전송**:
    - `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`를 사용하는 경우, 트랜잭션이 성공적으로 커밋된 후에 이벤트 핸들러가 실행됩니다. 따라서 알림 전송은 트랜잭션이 완료된 이후에 비동기적으로 수행되므로, 알림 전송이 실패해도 기존 트랜잭션의 결과에 영향을 미치지 않습니다.

- [STEP16 서비스설계 문서 작성 ](https://summer-floss-e9d.notion.site/13ef8b5879338064979bf636a93d2586?pvs=4)

### 리뷰 포인트
- 퍼블리셔와 핸들러를 infrastructure 레이어에 인터페이스와 구현체로 작성하여 이벤트를 처리하는 방안에 대한 작성이 잘 이루어졌는지 알려주신다면 감사합니다.
- 컨슈머, 리스너, 핸들러는 발행 도메인 패키지 내부가 아니라, 소비 도메인 패키지 내부에 작성하는게 적합하다고 생각합니다. 
  **알림**과 관련된 도메인에서 소비되므로 notification 도메인 패키지에 위치
  **유저 포인트 사용**과 관련된 기능에서 사용되므로 user 도메인 패키지 내에 두는 것이 옳은 설정인지 알려주시면 감사합니다.

  
